### PR TITLE
Fix crash for references without author or editor

### DIFF
--- a/lib/bibmarkdown/document.rb
+++ b/lib/bibmarkdown/document.rb
@@ -119,7 +119,7 @@ module BibMarkdown
       citeproc = @entries[key].to_citeproc
 
       # Ensure multi-part last names stick together
-      (citeproc["author"] || citeproc["editor"]).each do |author|
+      (citeproc["author"] || citeproc["editor"] || []).each do |author|
         if author.has_key? "non-dropping-particle"
           author["family"] = "#{author["non-dropping-particle"]} #{author["family"]}"
           author.delete "non-dropping-particle"


### PR DESCRIPTION
04add5db58d69ed9734600559b20ca21bc890e24 introduced a crash for references without an author or editor.